### PR TITLE
add WidgetBridge class ported from WidgetBridge.h

### DIFF
--- a/blynk.js
+++ b/blynk.js
@@ -237,6 +237,27 @@ var Blynk = function(auth, options) {
     };
   };
 
+  this.WidgetBridge = function(vPin) {
+    if (needsEmitter()) {
+      events.EventEmitter.call(this);
+    }
+    this.blynk = self;
+    this.mPin = vPin;
+
+    this.setAuthToken = function(token) {
+      self.sendMsg(MsgType.BRIDGE, null, [this.mPin, 'i', token]);
+    }
+    this.digitalWrite = function(pin, val) {
+      self.sendMsg(MsgType.BRIDGE, null, [this.mPin, 'dw', pin, val]);
+    }
+    this.analogWrite = function(pin, val) {
+      self.sendMsg(MsgType.BRIDGE, null, [this.mPin, 'aw', pin, val]);
+    }
+    this.virtualWrite = function(pin, val) {
+      self.sendMsg(MsgType.BRIDGE, null, [this.mPin, 'vw', pin, val]);
+    }
+  }
+
   if (needsEmitter()) {
     util.inherits(this.VirtualPin, events.EventEmitter);
   } else if (isBrowser()) {

--- a/examples/node-client-with-bridge.js
+++ b/examples/node-client-with-bridge.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env nodejs
+
+var Blynk = require('blynk-library');
+
+var blynk = new Blynk.Blynk('Your main api key', options = {
+  base_dir : '../'
+});
+
+var v1 = new blynk.VirtualPin(1);
+var v9 = new blynk.VirtualPin(9);
+var bridge1 = new blynk.WidgetBridge(31);
+
+v1.on('write', function(param) {
+  console.log('V1:', param);
+  bridge1.digitalWrite(13, param);
+});
+
+v9.on('read', function() {
+  v9.write(new Date().getSeconds());
+});
+
+blynk.on('connect', function() {
+  bridge1.setAuthToken('Your another api key');
+  console.log("Blynk ready.");
+});
+blynk.on('disconnect', function() { console.log("DISCONNECT"); });


### PR DESCRIPTION
I would like to control the Blynk from Node.js.
But bridge write function from node dummy board was unimplemented.
So I ported WidgetBridge.h to Blynk.WidgetBridge.