### PR TITLE
Add support voor MAP component (WidgetMAP)

### DIFF
--- a/blynk.js
+++ b/blynk.js
@@ -370,6 +370,15 @@ var Blynk = function(auth, options) {
       self.virtualWrite(this.pin, 0);
     };
   };
+  
+  this.WidgetMAP = function(vPin) {
+    this.pin = vPin;
+    
+    this.location = function(index, lat, lon, value) {
+      var locationdata = [index, lat, lon, value]
+      self.virtualWrite(this.pin, locationdata);
+    }
+  };
 
   if (needsEmitter()) {
     util.inherits(this.VirtualPin, events.EventEmitter);


### PR DESCRIPTION
The added code enables the user to use a MAP component for the phone APP in the same way the WidgetLED is used:

var mymap = new blynk.WidgetMAP(virtualport);
mymap.location(index,  lat, lon, value);

Tested it on a raspberry pi 3