### PR TITLE
Update client-ssl-local.js

### DIFF
--- a/examples/nodejs/client-ssl-local.js
+++ b/examples/nodejs/client-ssl-local.js
@@ -5,7 +5,7 @@ var Blynk = require('blynk-library');
 var AUTH = 'YOUR_AUTH_TOKEN';
 
 var blynk = new Blynk.Blynk(AUTH,
-  options= { addr:"127.0.0.1", port:8441 }
+  options= { addr:"127.0.0.1", port:8080 }
 );
 
 var v1 = new blynk.VirtualPin(1);


### PR DESCRIPTION
According to this: https://community.blynk.cc/t/js-library-keeps-connecting-and-disconnecting/23037/7

Also port 8080 worked for me with a local Blynk server setup on a Raspberry Pi 3B that also was also manipulating a specific GIPO pin.