### PR TITLE
Fix a bug which prevents opening a WebSocket.

### DIFF
--- a/blynk-browser.js
+++ b/blynk-browser.js
@@ -40,7 +40,7 @@ exports.WsClient = function(options) {
       self.sock.close();
     }
     try {
-      self.sock = new WebSocket('ws://' + self.addr + ':' + self.port + options.path);
+      self.sock = new WebSocket('ws://' + self.addr + ':' + self.port + self.path);
       self.sock.binaryType = 'arraybuffer';
       self.sock.onopen = function(evt) { done() };
       self.sock.onclose = function(evt) { self.emit('end'); };


### PR DESCRIPTION
This fixed a bug where it couldn't open a WebSocket:
DOMException: Failed to construct 'WebSocket': The URL 'ws://blynk-cloud.com:8082undefined' is invalid.